### PR TITLE
Use parens for grouping exponents in plain format.

### DIFF
--- a/src/display.cc
+++ b/src/display.cc
@@ -341,10 +341,11 @@ void print_pow::print_infix(std::ostream& str, exptree::iterator it)
 		str << "}";
 		}
 	else {
-		str << "**{";
+		str << "**"
+                    << (parent.output_format==exptree_output::out_plain?"(":"{");
 		++ch;
 		parent.get_printer(ch)->print_infix(str, ch);
-		str << "}";
+                str << (parent.output_format==exptree_output::out_plain?")":"}");
 		}
 	}
 


### PR DESCRIPTION
Maxima interprets braced expressions as sets, and does not simplify
exponents in that form.
